### PR TITLE
Fix folding ranges

### DIFF
--- a/src/ts/PklLanguageSupport.ts
+++ b/src/ts/PklLanguageSupport.ts
@@ -108,9 +108,9 @@ class PklLanguageSupport
     const tree = this.#parse(document);
     const captures = this.#foldsQuery.captures(tree.rootNode);
     return captures
-      .filter((it) => it.node.endPosition.column > it.node.startPosition.column)
+      .filter((it) => it.node.endPosition.row > it.node.startPosition.row)
       .map((it) => {
-        return new vscode.FoldingRange(it.node.startPosition.column, it.node.endPosition.column);
+        return new vscode.FoldingRange(it.node.startPosition.row, it.node.endPosition.row);
       });
   }
 }


### PR DESCRIPTION
`vscode.FoldingRange()` uses `row`; not `column`

Using [snippets.pkl](https://github.com/apple/pkl-vscode/blob/main/src/pkl/snippets.pkl) for reference

Before and After:  

![image](https://github.com/apple/pkl-vscode/assets/33529441/52eb3d2b-92bd-40e1-bcad-91f70411d0c2)  ![image](https://github.com/apple/pkl-vscode/assets/33529441/6a374e1d-3e96-44ff-88e8-e940976f1dd8)


