### PR TITLE
Fix brace token matching

### DIFF
--- a/src/pkl/pkl.tmLanguage.pkl
+++ b/src/pkl/pkl.tmLanguage.pkl
@@ -286,7 +286,7 @@ local builtInTypes: Pattern = new KeywordMatchPattern {
 
 local braces: MatchPattern = new {
   name = "meta.brace.pkl"
-  match = #"\b[(){}\[\]]\b"#
+  match = #"[(){}\[\]]"#
 }
 
 local intLiteral: MatchPattern = new {


### PR DESCRIPTION
Currently the TextMate grammar does not tokenize brackets `{}[]()`

Before:
![image](https://github.com/apple/pkl-vscode/assets/33529441/73e03a05-e011-488d-999e-c8e3aa4f8c13)

After:
Braces are now correctly captured with the token `meta.brace.pkl`
![image](https://github.com/apple/pkl-vscode/assets/33529441/c07b693e-600c-41c3-aee9-3523189a5696)
