### PR TITLE
Coalesce `null` to `undefined`

### DIFF
--- a/src/ts/config.ts
+++ b/src/ts/config.ts
@@ -17,9 +17,9 @@
 import { workspace } from "vscode";
 import { CONFIG_JAVA_PATH, CONFIG_LSP_DEBUG_PORT, CONFIG_LSP_PATH } from "./consts";
 
-const getConfig = <T>(configName: string) => {
+const getConfig = <T>(configName: string): T | undefined => {
   const value = workspace.getConfiguration().get<T>(configName);
-  if (value === "") {
+  if (value === "" || value === null) {
     return undefined;
   }
   return value;


### PR DESCRIPTION
The API docs say that `getConfiguration().get()` returns undefined, but users are reporting that it returns `null` in practice.