### PR TITLE
Fix link to features page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pkl language support for [Visual Studio Code](https://code.visualstudio.com).
 
 ## Documentation
 
-The [user documentation](https://pkl-lang.org/vscode/current/index.html) provides [installation instructions](https://pkl-lang.org/vscode/current/installation.html) and a [feature overview](https://pkl-lang.org/vscode/current/features/index.html).
+The [user documentation](https://pkl-lang.org/vscode/current/index.html) provides [installation instructions](https://pkl-lang.org/vscode/current/installation.html) and a [feature overview](https://pkl-lang.org/vscode/current/features.html).
 
 ## Community
 


### PR DESCRIPTION
The link to the features page in the README is wrong.

This PR fixes it!
