### PR TITLE
Add LSP socket option

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,14 @@
           "default": 5005,
           "description": "Debug port to launch pkl-lsp. This is an internal developer option."
         },
+        "pkl.lsp.socket.port": {
+          "type": "number",
+          "description": "Port of the LSP socket to talk to. Setting this takes precedence over `pkl.lsp.path`. This is an internal developer option."
+        },
+        "pkl.lsp.socket.host": {
+          "type": "string",
+          "description": "Host of the LSP socket to talk to. If unset or empty, defaults to localhost. This is an internal developer option."
+        },
         "pkl.cli.path": {
           "type": "string",
           "default": null,

--- a/src/ts/config.ts
+++ b/src/ts/config.ts
@@ -15,7 +15,13 @@
  */
 
 import { workspace } from "vscode";
-import { CONFIG_JAVA_PATH, CONFIG_LSP_DEBUG_PORT, CONFIG_LSP_PATH } from "./consts";
+import {
+  CONFIG_JAVA_PATH,
+  CONFIG_LSP_DEBUG_PORT,
+  CONFIG_LSP_PATH,
+  CONFIG_LSP_SOCKET_HOST,
+  CONFIG_LSP_SOCKET_PORT,
+} from "./consts";
 
 const getConfig = <T>(configName: string): T | undefined => {
   const value = workspace.getConfiguration().get<T>(configName);
@@ -36,6 +42,14 @@ const config = {
 
   get lspDebugPort() {
     return getConfig<number>(CONFIG_LSP_DEBUG_PORT);
+  },
+
+  get lspSocketPort() {
+    return getConfig<number>(CONFIG_LSP_SOCKET_PORT);
+  },
+
+  get lspSocketHost() {
+    return getConfig<string>(CONFIG_LSP_SOCKET_HOST);
   },
 };
 

--- a/src/ts/consts.ts
+++ b/src/ts/consts.ts
@@ -21,6 +21,10 @@ export const CONFIG_JAVA_PATH = "pkl.lsp.java.path";
 
 export const CONFIG_LSP_PATH = "pkl.lsp.path";
 
+export const CONFIG_LSP_SOCKET_PORT = "pkl.lsp.socket.port";
+
+export const CONFIG_LSP_SOCKET_HOST = "pkl.lsp.socket.host";
+
 export const CONFIG_LSP_DEBUG_PORT = "pkl.lsp.debug.port";
 
 // only used by the LSP server


### PR DESCRIPTION
This adds an option that causes the VSCode client to connect to an already listening LSP server.