### PR TITLE
Ensure production dependencies are included in vsix package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,7 +4,22 @@
 !README.md
 !language-configuration.json
 !package.json
+!package-lock.json
 !out/**
 !queries/*
 !img/*
 !LICENSE
+
+# Ensure that prod dependencies are included.
+#
+# This is computed from:
+# `cat package-lock.json | jq -r '.packages | map_values(select(.dev != true)) | keys[] | select(. != "")'`
+!node_modules/balanced-match
+!node_modules/brace-expansion
+!node_modules/minimatch
+!node_modules/semver
+!node_modules/vscode-jsonrpc
+!node_modules/vscode-languageclient
+!node_modules/vscode-languageserver-protocol
+!node_modules/vscode-languageserver-types
+!node_modules/web-tree-sitter

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.18.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "vscode-languageclient": "^9.0.1"
+        "vscode-languageclient": "^9.0.1",
+        "web-tree-sitter": "^0.25.3"
       },
       "devDependencies": {
         "@apple/tree-sitter-pkl": "^0.18.0",
@@ -23,8 +24,7 @@
         "tslint": "^5.8.0",
         "typescript": "^4.7.3",
         "vsce": "2.9",
-        "vscode-test": "^1.6.1",
-        "web-tree-sitter": "^0.25.3"
+        "vscode-test": "^1.6.1"
       },
       "engines": {
         "vscode": "^1.59.0"
@@ -2281,8 +2281,7 @@
     "node_modules/web-tree-sitter": {
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.3.tgz",
-      "integrity": "sha512-e0hdXG+nJ18Zd/QJFhSx0DNTSMz7miwUjKyJ/lglTnZo6ke08++BQzXkaeaqnGJFi9qq+nPJg2L8hYAjduToHQ==",
-      "dev": true
+      "integrity": "sha512-e0hdXG+nJ18Zd/QJFhSx0DNTSMz7miwUjKyJ/lglTnZo6ke08++BQzXkaeaqnGJFi9qq+nPJg2L8hYAjduToHQ=="
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
     "clone-grammar": "git submodule update --init --recursive"
   },
   "dependencies": {
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^9.0.1",
+    "web-tree-sitter": "^0.25.3"
   },
   "devDependencies": {
     "@apple/tree-sitter-pkl": "^0.18.0",
@@ -178,7 +179,6 @@
     "tslint": "^5.8.0",
     "typescript": "^4.7.3",
     "vsce": "2.9",
-    "vscode-test": "^1.6.1",
-    "web-tree-sitter": "^0.25.3"
+    "vscode-test": "^1.6.1"
   }
 }


### PR DESCRIPTION
After we switched from esbuild, we no longer bundle these dependencies into a single JS file. Because of this, we now need to include our NPM dependencies in our node_modules folder.