### PR TITLE
Bump bundled pkl-lsp version, consider 0.+ versions compatible

### DIFF
--- a/src/ts/Semver.ts
+++ b/src/ts/Semver.ts
@@ -84,9 +84,6 @@ export default class Semver {
   }
 
   isCompatibleWith(other: Semver) {
-    if (this.major === 0) {
-      return other.major === 0 && this.minor === other.minor && this.patch >= other.patch;
-    }
     return this.major === other.major && this.minor >= other.minor;
   }
 }

--- a/src/ts/consts.ts
+++ b/src/ts/consts.ts
@@ -42,7 +42,7 @@ export const COMMAND_OPEN_WORKSPACE_SETTINGS = "workbench.action.openSettings";
 
 export const COMMAND_RELOAD_WORKSPACE_WINDOW = "workbench.action.reloadWindow";
 
-export const BUNDLED_LSP_VERSION = "0.1.1";
+export const BUNDLED_LSP_VERSION = "0.3.1";
 
 /**
  * The directory that pkl-lsp distributions get saved to.


### PR DESCRIPTION
This bumps pkl-lsp to 0.3.0.
Additionally, it considers minor version bumps of 0.x versions as compatible.

This means that new release of pkl-lsp can be automatically downloaded. One implication here is that we cannot introduce breaking changes to the LSP without releasing a new major version.